### PR TITLE
Switch to third-party order/properties-order rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ var displayAndBoxModel = []
 module.exports = {
   "extends": "stylelint-config-standard",
   "rules": {
-    "declaration-block-properties-order": [
+    "order/properties-order": [
       { "properties": positioning.concat(displayAndBoxModel), "unspecified": "bottomAlphabetical" }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "dependencies": {
     "stylelint": "^7.0.3",
-    "stylelint-config-standard": "^11.0.0"
+    "stylelint-config-standard": "^11.0.0",
+    "stylelint-order": "^0.4.4"
   },
   "devDependencies": {
     "eslint": "^3.2.0"


### PR DESCRIPTION
This is a really simple maintenance update to avoid a Stylelint deprecation warning about [the `declaration-block-properties-order` rule](https://stylelint.io/user-guide/rules/declaration-block-properties-order/#declaration-block-properties-order). Now the package uses [`stylelint-order`](https://github.com/hudochenkov/stylelint-order) instead!