### PR TITLE
Force `composes` to come first when using css-modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,11 @@ function minMax(suffix) {
   return [suffix, "min-" + suffix, "max-" + suffix];
 }
 
+var cssModules = []
+  .concat([
+    "composes"
+  ]);
+
 var positioning = []
   .concat([
     "position",
@@ -58,7 +63,9 @@ module.exports = {
   "extends": "stylelint-config-standard",
   "rules": {
     "order/properties-order": [
-      positioning.concat(displayAndBoxModel),
+      cssModules
+      .concat(positioning)
+      .concat(displayAndBoxModel),
       { "unspecified": "bottomAlphabetical" }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-idiomatic-order",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "stylelint + idiomatic-css = ❤️",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
According to the [css-modules docs](https://github.com/css-modules/css-modules/blob/master/README.md#composition) `composes` must come before any other rules. This PR makes sure that happens. 

Let me know if skipped over anything!