### PR TITLE
fix: remove duplicate border rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,15 +70,13 @@ var displayAndBoxModel = []
     "order"
   ])
   .concat(trbl("padding"))
-  .concat(trbl("border"))
+  .concat([]
+    .concat(border())
+    .concat(border("top"))
+    .concat(border("right"))
+    .concat(border("bottom"))
+    .concat(border("left")))
   .concat(trbl("margin"));
-
-var borders = []
-  .concat(border())
-  .concat(border("top"))
-  .concat(border("right"))
-  .concat(border("bottom"))
-  .concat(border("left"));
 
 module.exports = {
   "plugins": "stylelint-order",
@@ -87,8 +85,7 @@ module.exports = {
       []
         .concat(cssModules)
         .concat(positioning)
-        .concat(displayAndBoxModel)
-        .concat(borders),
+        .concat(displayAndBoxModel),
       { "unspecified": "bottomAlphabetical" }
     ]
   }


### PR DESCRIPTION
Currently duplicate border rules (since https://github.com/ream88/stylelint-config-idiomatic-order/pull/18)

This breaks the `padding -> border -> margin` box model expectation of idiomatic css and instead expects `padding -> margin -> border`

Current output:

```
[
  'composes',
  'position',
  'z-index',
  'top',
  'right',
  'bottom',
  'left',
  'display',
  'overflow',
  'width',
  'min-width',
  'max-width',
  'height',
  'min-height',
  'max-height',
  'box-sizing',
  'flex',
  'flex-basis',
  'flex-direction',
  'flex-flow',
  'flex-grow',
  'flex-shrink',
  'flex-wrap',
  'align-content',
  'align-items',
  'align-self',
  'justify-content',
  'order',
  'padding',
  'padding-top',
  'padding-right',
  'padding-bottom',
  'padding-left',
  'border',
  'border-top',
  'border-right',
  'border-bottom',
  'border-left',
  'margin',
  'margin-top',
  'margin-right',
  'margin-bottom',
  'margin-left',
  'border',
  'border-width',
  'border-style',
  'border-color',
  'border-top',
  'border-top-width',
  'border-top-style',
  'border-top-color',
  'border-right',
  'border-right-width',
  'border-right-style',
  'border-right-color',
  'border-bottom',
  'border-bottom-width',
  'border-bottom-style',
  'border-bottom-color',
  'border-left',
  'border-left-width',
  'border-left-style',
  'border-left-color'
]
```

New output:

```
[
  'composes',
  'position',
  'z-index',
  'top',
  'right',
  'bottom',
  'left',
  'display',
  'overflow',
  'width',
  'min-width',
  'max-width',
  'height',
  'min-height',
  'max-height',
  'box-sizing',
  'flex',
  'flex-basis',
  'flex-direction',
  'flex-flow',
  'flex-grow',
  'flex-shrink',
  'flex-wrap',
  'align-content',
  'align-items',
  'align-self',
  'justify-content',
  'order',
  'padding',
  'padding-top',
  'padding-right',
  'padding-bottom',
  'padding-left',
  'border',
  'border-width',
  'border-style',
  'border-color',
  'border-top',
  'border-top-width',
  'border-top-style',
  'border-top-color',
  'border-right',
  'border-right-width',
  'border-right-style',
  'border-right-color',
  'border-bottom',
  'border-bottom-width',
  'border-bottom-style',
  'border-bottom-color',
  'border-left',
  'border-left-width',
  'border-left-style',
  'border-left-color',
  'margin',
  'margin-top',
  'margin-right',
  'margin-bottom',
  'margin-left'
]
```