### PR TITLE
Support the property 'all' that should be before all other properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,8 @@ var cssModules = []
     'composes'
   ])
 
+var reset = ['all']
+
 var positioning = []
   .concat([
     'position',
@@ -84,6 +86,7 @@ module.exports = {
     'order/properties-order': [
       []
         .concat(cssModules)
+        .concat(reset)
         .concat(positioning)
         .concat(displayAndBoxModel),
       { 'unspecified': 'bottomAlphabetical' }

--- a/test/expected.css
+++ b/test/expected.css
@@ -53,6 +53,7 @@ article, aside, figcaption, figure, footer, header, hgroup, main, nav, section {
 }
 
 body {
+  all: unset;
   margin: 0;
   background-color: #fff;
   color: #212529;

--- a/test/fixture.css
+++ b/test/fixture.css
@@ -61,6 +61,7 @@ body {
   color: #212529;
   text-align: left;
   background-color: #fff;
+  all: unset;
 }
 
 [tabindex="-1"]:focus {

--- a/test/test.js
+++ b/test/test.js
@@ -13,7 +13,7 @@ function testOrder () {
   const fixture = fs.readFileSync(path.join(__dirname, 'fixture.css'), 'utf8')
   const expected = fs.readFileSync(path.join(__dirname, 'expected.css'), 'utf8')
 
-  stylelint.lint({
+  return stylelint.lint({
     code: fixture,
     config: require('..'),
     fix: true
@@ -24,4 +24,12 @@ function testOrder () {
 }
 
 testConfigFile()
-testOrder()
+testOrder().catch((e) => {
+  if (process.env.DEBUG) {
+    console.error(e.message)
+  } else {
+    console.error(e.name)
+    console.error('Run with the DEBUG environement variable to see more.')
+  }
+  process.exit(-1)
+})

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,8 @@ function testConfigFile () {
   assert.doesNotThrow(() => {
     require(path.join(__dirname, '..', 'index.js'))
   })
+
+  return Promise.resolve()
 }
 
 function testOrder () {
@@ -19,17 +21,13 @@ function testOrder () {
     fix: true
   }).then(result => {
     assert.strictEqual(result.errored, false)
-    assert.strictEqual(result.output, expected)
+    assert.strictEqual(result.output, expected, 'Stylelint output does not equal expected output')
   })
 }
 
-testConfigFile()
-testOrder().catch((e) => {
-  if (process.env.DEBUG) {
-    console.error(e.message)
-  } else {
-    console.error(e.name)
-    console.error('Run with the DEBUG environement variable to see more.')
-  }
-  process.exit(-1)
-})
+Promise
+  .all([testConfigFile(), testOrder()])
+  .catch(e => {
+    console.error(e.name, e.message)
+    process.exit(-1)
+  })


### PR DESCRIPTION
The problem comes from such a CSS code:
```css
 .can-select-content-input { 
   all: unset; 
   width: 100%; 
   text-overflow: ellipsis; 
 }
```
The plugin would want to move `all: unset` below `width` which is incorrect.

See https://github.com/firefox-devtools/profiler/issues/2131 for more context.